### PR TITLE
Fixed Reuse QR Code

### DIFF
--- a/app/src/main/java/com/example/qr_dasher/Attendee.java
+++ b/app/src/main/java/com/example/qr_dasher/Attendee.java
@@ -27,6 +27,7 @@ import androidx.core.content.ContextCompat;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FieldPath;
@@ -39,6 +40,7 @@ import com.google.firebase.firestore.QuerySnapshot;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 /**
  * Activity for attendees of an event. Allows attendees to view notifications, edit their profile,

--- a/app/src/main/java/com/example/qr_dasher/CreateEventOrganizer.java
+++ b/app/src/main/java/com/example/qr_dasher/CreateEventOrganizer.java
@@ -98,6 +98,7 @@ public class CreateEventOrganizer extends AppCompatActivity implements DatePicke
     private int savedHour = 0;
     private int savedMinute = 0;
     private static final int PICK_IMAGE_REQUEST = 1;
+    private static final int SCAN_QR_REQUEST_CODE = 2;
     private boolean twoQRcodes = false;
 
     /**


### PR DESCRIPTION
1. Added scanning functionality to reuse a qr code, which changed qrimage and the content field in firebase.
2. Changed Attendee class to reflect this change while checking, so we get the content field which is just the output of the qrcode, and then we get the event_id from that for either promotional or attendee qr code depending on where the content matches.
3. Scanning now works for the new qr code and the attendee can check in.